### PR TITLE
Add filtered dataset summary metrics

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ numpy>=1.24.0
 plotly>=5.20.0
 scikit-learn>=1.4.0
 networkx>=3.2.0
+sentence-transformers>=2.2.2
+openpyxl>=3.1.0


### PR DESCRIPTION
## Summary
- add a high-level filter summary helper to surface event, fatality, country, and actor counts for the active view
- show the active date range and leading countries immediately after applying global filters to reinforce context for the six-month default

## Testing
- python -m compileall ACLED_analytics.py

------
https://chatgpt.com/codex/tasks/task_e_68e4f7b22c50832297172396a803fef5